### PR TITLE
Pass request through to handler in all cases

### DIFF
--- a/src/bismuth/codeblocks/function_code_block.py
+++ b/src/bismuth/codeblocks/function_code_block.py
@@ -6,6 +6,7 @@ class FunctionCodeBlock(BaseCodeBlock):
     """
     Extends BaseCodeBlock. Run a python function with some requirements.
     """
+
     # Flag for if this block makes any network requests.
     network_enabled: bool
     # Function that will be run by `execute()`.
@@ -21,8 +22,8 @@ class FunctionCodeBlock(BaseCodeBlock):
         self.network_enabled = network_enabled
         self.func = func
 
-    def exec(self, **kwargs: Any) -> Any:
+    def exec(self, *args, **kwargs: Any) -> Any:
         """
         Run a subset of arbitrary python functions as defined by Bismuth provided args and kwargs.
         """
-        return self.func(**kwargs)
+        return self.func(*args, **kwargs)

--- a/src/bismuth/codeblocks/test_api_code_block.py
+++ b/src/bismuth/codeblocks/test_api_code_block.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from flask import Request
 from unittest.mock import MagicMock
 from .api_code_block import APICodeBlock
 from .function_code_block import FunctionCodeBlock
@@ -8,10 +9,24 @@ from .function_code_block import FunctionCodeBlock
 # Fixture to setup the APICodeBlock with mocked routes
 @pytest.fixture
 def api_block():
-    os.environ['BISMUTH_AUTH'] = "TEST_AUTH"
+    os.environ["BISMUTH_AUTH"] = "TEST_AUTH"
     api_block = APICodeBlock()
     api_block.app.testing = True
     return api_block
+
+
+def test_request_passed_through_auth_callback(api_block):
+    def request_passed(request: Request):
+        if type(request) != Request:
+            return 500
+        else:
+            return 200
+
+    api_block.add_route("/request_passed", {"GET": request_passed})
+
+    with api_block.app.test_client() as client:
+        response = client.get("/request_passed")
+        assert response.status_code == 200
 
 
 def test_add_route(api_block):
@@ -27,8 +42,9 @@ def test_add_route(api_block):
 
 
 def test_add_route_bare_func(api_block):
-    def func():
+    def func(*args):
         return {"message": "mock response"}
+
     api_block.add_route("/mock", {"get": func})
 
     with api_block.app.test_client() as client:


### PR DESCRIPTION
This PR adds a default arg for the flask request otherwise, it is never passed to the handler and currently there is no way to access the flask request in a handler method in ApiCodeBlock. 

This is not a problem in ApiCodeBlockWithStorage because of dynamic resource in where request is injected.